### PR TITLE
Add README to display on @graalvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+<img src="https://github.com/graalvm/.github/blob/main/Frame%202456.png" alt="GraalVM logo">


### PR DESCRIPTION
Per [GitHub's documentation](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) on `.github` repositories, one needs to have content in a `README.md` file in order to show the content on the organizations homepage. Thus, I've added a README file here with the GraalVM image that already exists in the repository.